### PR TITLE
Small changes to README.md and injector/README.md to make build commands clearer and update desync detection details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ You can also pause the replay by pressing `z`. When the replay is paused this wa
 Mod can be buit with `cargo` using the `nightly-i686-pc-windows-msvc` toolchain.  
 When building from source please remember to add the `--release`/`-r` flag.
 
+```
+rustup toolchain install nightly-i686-pc-windows-msvc
+cargo +nightly-i686-pc-windows-msvc build --release
+```
+
 ## Common problems  
 
 - Game doesn't load: check if the ini is valid according to the example ini provided in this repository, and is placed alongside the mod without any changes to it's name, and check for mod conflicts by disabling all other mods, and adding them back one by one.  

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository also contains a stripped down version version of the crate [ilho
 - navigate to your Hisoutensoku folder;
 - You should see a subfolder called `modules`, and a file called `SWRSToys.ini`
 - drop the giuroll folder from this zip into `modules`
-- add the following line into your `SWRSTOYS.ini`
+- add the following line into your `SWRSToys.ini`
 `giuroll=modules/giuroll/giuroll.dll`
 
 - find the following line
@@ -21,15 +21,9 @@ This repository also contains a stripped down version version of the crate [ilho
 `; SWRSokuRoll=modules/SWRSokuRoll/SWRSokuRoll.dll`
 
 ### For users without SWRSToys
-Mod can be loaded using the [Injector](/injector/).  
-The injector needs to be built from source, and placed alongside the dll and the ini, which can be found in official releases.
-- Start th123.exe 
-- Run the injector  
+See the [Injector](/injector/).  
 
-if sucessfull, you should see a message.  
-If the injector closes abruptly, contact me about it.
-
-### More information about the usage in game is available in the `installation and usage.txt` file inside the distributed zip
+**More usage information is available in the `installation and usage.txt` file within the distributed zip file.**
 
 ## Replay rewind  
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ See the [Injector](/injector/).
 ## Replay rewind  
 
 In replay mode pressing `q` will start rewinding, using keys that modify playback speed (A/S/D) will affect the rewind speed.  
-You can also pause the replay by pressing `z`. When the replay is paused this way you can move frame by frame, backwards or forwards, by using `s` and `d`
+You can also pause the replay by pressing `z`. When the replay is paused this way you can move frame by frame, backwards or forwards, by using `s` and `d`.
+
+## Desync detection
+Giuroll is able to detect desyncs intrinsically, but displaying them in-game requires a [secondary mod](https://github.com/kookie2332/Giuroll-Desync-Detector).
+
+There is no guarantee that the desync detector will always correctly identify when a game is desynced or not. You can contact me if they:
+- are common,
+- persist after game restarts, or
+- do not occur when using SokuRoll
 
 ## Building from source
 
@@ -44,8 +52,6 @@ cargo +nightly-i686-pc-windows-msvc build --release
 
 - Game doesn't load: check if the ini is valid according to the example ini provided in this repository, and is placed alongside the mod without any changes to it's name, and check for mod conflicts by disabling all other mods, and adding them back one by one.  
 - Failed to connect: either player is using an incompatible version of giuroll, or is not using it at all.  
-- Game desynced: I'm planning on adding a desync detector to make debugging desyncs easier, but since desyncs also occur with SokuRoll there is no guarantee they are caused solely by the rollback. If the desyncs are common, persists between game restarts, and are not appearing with Sokuroll, you can contact me about it.
-
 
 you can contact me about any issues through discord: `@giufin` in DMs.
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,20 @@ This repository also contains a stripped down version version of the crate [ilho
 ## Usage  
 
 ### For [SWRSToys](https://github.com/SokuDev/SokuMods/) users
-- navigate to your Hisoutensoku folder;
-- You should see a subfolder called `modules`, and a file called `SWRSToys.ini`
-- drop the giuroll folder from this zip into `modules`
-- add the following line into your `SWRSToys.ini`
-`giuroll=modules/giuroll/giuroll.dll`
-
-- find the following line
-`SWRSokuRoll=modules/SWRSokuRoll/SWRSokuRoll.dll`
-- add a `;` at the beginning of that line, making it
-`; SWRSokuRoll=modules/SWRSokuRoll/SWRSokuRoll.dll`
+1. Navigate to your Hisoutensoku folder. You should see a subfolder called `modules`, and a file called `SWRSToys.ini`.
+2. Drop the giuroll folder from this zip into `modules`
+3. Add the following line into your `SWRSToys.ini`
+```
+giuroll=modules/giuroll/giuroll.dll
+```
+4. find the following line
+`
+SWRSokuRoll=modules/SWRSokuRoll/SWRSokuRoll.dll
+`
+and add a `;` at the beginning of that line, making it
+```
+; SWRSokuRoll=modules/SWRSokuRoll/SWRSokuRoll.dll
+```
 
 ### For users without SWRSToys
 See the [Injector](/injector/).  

--- a/injector/README.md
+++ b/injector/README.md
@@ -7,21 +7,16 @@ Applies Giuroll to Hisoutensoku without requiring `SWRSToys`. Works akin to the 
 cd <...>/giuroll/injector
 ```
 
-2. If you are using a 64-bit PC, compile with
-```
-cargo +nightly-x86_64-pc-windows-msvc build --release
-``` 
-If you are using a 32-bit PC, compile with
+2. Compile with
 ```
 cargo +nightly-i686-pc-windows-msvc build --release
 ```
 
-
 ## Usage
-1. Ensure that `th123.exe`, `injector.exe`, `giuroll.dll` and `giuroll.ini` are all in the same directory,
+1. Ensure that `injector.exe`, `giuroll.dll` and `giuroll.ini` are all in the same directory,
 2. Start `th123.exe`,
 3. Run `injector.exe`
 
-If successful, the title of the game window will include `Giuroll <version_number>` at the end.
+If successful, the console window will display the words `Injection successful` for a few seconds before closing, and the title of the game window will include `Giuroll <version_number>` at the end.
 
 If the injector closes abruptly, contact me about it.

--- a/injector/README.md
+++ b/injector/README.md
@@ -2,20 +2,26 @@
 Applies Giuroll to Hisoutensoku without requiring `SWRSToys`. Works akin to the legacy `SokurollLoader.exe` used in older copies of the game.
 
 ## Compilation
+1. Navigate to this directory in the command prompt
+```
+cd <...>/giuroll/injector
+```
+
+2. If you are using a 64-bit PC, compile with
+```
+cargo +nightly-x86_64-pc-windows-msvc build --release
+``` 
 If you are using a 32-bit PC, compile with
 ```
 cargo +nightly-i686-pc-windows-msvc build --release
 ```
-If you are using a 64-bit PC, compile with
-```
-cargo +nightly-x86_64-pc-windows-msvc build --release
-```
+
 
 ## Usage
-- Ensure that `th123.exe`, `injector.exe`, `giuroll.dll` and `giuroll.ini` are all in the same directory,
-- Start `th123.exe`,
-- Run `injector.exe`
+1. Ensure that `th123.exe`, `injector.exe`, `giuroll.dll` and `giuroll.ini` are all in the same directory,
+2. Start `th123.exe`,
+3. Run `injector.exe`
 
-If successful, the title of the game window will include the word `Giuroll <version_number>` at the end.
+If successful, the title of the game window will include `Giuroll <version_number>` at the end.
 
 If the injector closes abruptly, contact me about it.

--- a/injector/README.md
+++ b/injector/README.md
@@ -1,11 +1,21 @@
 # Injector for the giuroll DLL
+Applies Giuroll to Hisoutensoku without requiring `SWRSToys`. Works akin to the legacy `SokurollLoader.exe` used in older copies of the game.
 
 ## Compilation
-compile with `cargo` using one of the `_-686-pc-windows-msvc` toolchains.
+If you are using a 32-bit PC, compile with
+```
+cargo +nightly-i686-pc-windows-msvc build --release
+```
+If you are using a 64-bit PC, compile with
+```
+cargo +nightly-x86_64-pc-windows-msvc build --release
+```
 
 ## Usage
-- Start th123.exe 
-- Run the injector  
+- Ensure that `th123.exe`, `injector.exe`, `giuroll.dll` and `giuroll.ini` are all in the same directory,
+- Start `th123.exe`,
+- Run `injector.exe`
 
-if sucessfull, you should see a message.  
+If successful, the title of the game window will include the word `Giuroll <version_number>` at the end.
+
 If the injector closes abruptly, contact me about it.


### PR DESCRIPTION
- Adds build commands to the README files as mentioned in the title to make it easier to build the dll as well as the injector,
- Makes the purpose of the `injector.exe` file clear and well as how to properly use it after build,
- Adds details on desync detection.

