### PR TITLE
Improve replay takeover

### DIFF
--- a/giuroll.ini
+++ b/giuroll.ini
@@ -21,6 +21,11 @@ decrease_delay_key=0x0A
 increase_delay_key=0x0B
 toggle_network_stats=0x09
 
+exit_takeover=0x10
+p1_takeover=0x11
+p2_takeover=0x12
+set_or_retry_takeover=0x13
+
 [Netplay]
 default_delay=2
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1077,6 +1077,11 @@ fn truer_exec(filename: PathBuf) -> Option<()> {
         })
     };
 
+    let new = unsafe {
+        ilhook::x86::Hooker::new(0x00482689, HookType::JmpToRet(is_replay_over), 0).hook(5)
+    };
+    std::mem::forget(new);
+
     Some(())
 }
 
@@ -1232,7 +1237,7 @@ use core::sync::atomic::AtomicU8;
 
 use crate::{
     netcode::{send_packet, send_packet_untagged},
-    replay::{apause, clean_replay_statics, handle_replay},
+    replay::{apause, clean_replay_statics, handle_replay, is_replay_over},
     rollback::CHARSIZEDATA,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,10 @@ fn truer_exec(filename: PathBuf) -> Option<()> {
     let inc = read_ini_int_hex(&conf, "Keyboard", "increase_delay_key", 0);
     let dec = read_ini_int_hex(&conf, "Keyboard", "decrease_delay_key", 0);
     let net = read_ini_int_hex(&conf, "Keyboard", "toggle_network_stats", 0);
+    let exit_takeover = read_ini_int_hex(&conf, "Keyboard", "exit_takeover", 0x10);
+    let p1_takeover = read_ini_int_hex(&conf, "Keyboard", "p1_takeover", 0x11);
+    let p2_takeover = read_ini_int_hex(&conf, "Keyboard", "p2_takeover", 0x12);
+    let set_or_retry_takeover = read_ini_int_hex(&conf, "Keyboard", "set_or_retry_takeover", 0x13);
     let spin = read_ini_int_hex(&conf, "FramerateFix", "spin_amount", 1500);
     let f62_enabled = read_ini_bool(&conf, "FramerateFix", "enable_f62", cfg!(feature = "f62"));
     let network_menu = read_ini_bool(&conf, "Netplay", "enable_network_stats_by_default", false);
@@ -331,6 +335,10 @@ fn truer_exec(filename: PathBuf) -> Option<()> {
         INCREASE_DELAY_KEY = inc as u8;
         DECREASE_DELAY_KEY = dec as u8;
         TOGGLE_STAT_KEY = net as u8;
+        TAKEOVER_KEYS_SCHEME[0] = exit_takeover as u8;
+        TAKEOVER_KEYS_SCHEME[1] = p1_takeover as u8;
+        TAKEOVER_KEYS_SCHEME[2] = p2_takeover as u8;
+        TAKEOVER_KEYS_SCHEME[3] = set_or_retry_takeover as u8;
         TOGGLE_STAT = network_menu;
         LAST_DELAY_VALUE = default_delay as usize;
         DEFAULT_DELAY_VALUE = default_delay as usize;
@@ -1562,6 +1570,8 @@ static mut DECREASE_DELAY_KEY: u8 = 0;
 
 static mut TOGGLE_STAT_KEY: u8 = 0;
 
+static mut TAKEOVER_KEYS_SCHEME: [u8; 4] = [0, 0, 0, 0];
+
 static mut TOGGLE_STAT: bool = false;
 static mut LAST_TOGGLE: bool = false;
 
@@ -1722,6 +1732,7 @@ unsafe extern "cdecl" fn main_hook(a: *mut ilhook::x86::Registers, _b: usize) {
                 cur_speed,
                 cur_speed_iter,
                 state_sub_count,
+                &TAKEOVER_KEYS_SCHEME,
             )
         } //2 is replay
         (1, true) => {

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -89,6 +89,7 @@ pub unsafe fn clean_replay_statics() {
 
     RE_PLAY = None;
     DISABLE_PAUSE = false;
+    set_keys_availability_in_takeover(true);
 }
 
 pub unsafe extern "cdecl" fn disable_x_in_takeover(
@@ -102,6 +103,18 @@ pub unsafe extern "cdecl" fn disable_x_in_takeover(
         0x4826bb
     } else {
         0x4825e5
+    }
+}
+
+unsafe fn set_keys_availability_in_takeover(enable: bool) {
+    for n in 0..=1 {
+        let input_manager = *((0x00898680 as *const *mut u32).offset(n));
+        if input_manager != 0 as *mut u32 {
+            if !enable {
+                *input_manager.offset(0x18) = 0; // clear InputManager.inKeys
+            }
+            *input_manager.offset(0x19) = !enable as u32; // InputManager.readInKeys
+        }
     }
 }
 
@@ -133,6 +146,7 @@ pub unsafe fn handle_replay(
         if let Some(rprp) = RE_PLAY.take() {
             override_target_frame = Some(rprp.frame as u32 - 1);
             DISABLE_PAUSE = false;
+            set_keys_availability_in_takeover(true);
         }
     }
 
@@ -162,6 +176,7 @@ pub unsafe fn handle_replay(
         RE_PLAY_PAUSE = 40;
         RE_PLAY_PAUSE = 40;
         DISABLE_PAUSE = true;
+        set_keys_availability_in_takeover(false);
     }
 
     let rdown = read_key_better(scheme[3]);

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -101,7 +101,9 @@ pub unsafe fn clean_replay_statics() {
 
     RE_PLAY = None;
     DISABLE_PAUSE = false;
-    set_keys_availability_in_takeover(true);
+    if !RE_PLAY.is_none() {
+        set_keys_availability_in_takeover(true);
+    }
 }
 
 pub unsafe extern "cdecl" fn disable_x_in_takeover(

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -99,10 +99,10 @@ pub unsafe fn clean_replay_statics() {
         a.did_happen();
     }
 
-    RE_PLAY = None;
     DISABLE_PAUSE = false;
-    if !RE_PLAY.is_none() {
+    if RE_PLAY.is_some() {
         set_keys_availability_in_takeover(true);
+        RE_PLAY = None;
     }
 }
 

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -82,6 +82,18 @@ pub unsafe extern "cdecl" fn apause(_a: *mut ilhook::x86::Registers, _b: usize) 
     //if ISDEBUG { info!("input: {:?}", input[16]) };
 }
 
+pub unsafe extern "cdecl" fn is_replay_over(
+    a: *mut ilhook::x86::Registers,
+    _b: usize,
+    _c: usize,
+) -> usize {
+    // https://stackoverflow.com/a/46134764
+    let ori_fun: unsafe extern "fastcall" fn(u32) -> bool =
+        unsafe { std::mem::transmute(0x00480860) };
+    (*a).eax = (ori_fun((*a).ecx) && RE_PLAY.is_none()) as u32;
+    return 0x00482689 + 5;
+}
+
 pub unsafe fn clean_replay_statics() {
     for a in std::mem::replace(&mut *FRAMES.lock().unwrap(), vec![]) {
         a.did_happen();

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -184,6 +184,7 @@ pub unsafe fn handle_replay(
     cur_speed: &mut u32,
     cur_speed_iter: &mut u32,
     weird_counter: &mut u32,
+    scheme: &[u8;4]
 ) {
     if let Some(x) = FRAMES.lock().unwrap().last_mut() {
         //TODO
@@ -197,7 +198,7 @@ pub unsafe fn handle_replay(
         }
     }
 
-    let scheme = [0x02, 0x03, 0x04, 0x05];
+    //let scheme = [0x02, 0x03, 0x04, 0x05];
     //let scheme = [0x10, 0x11, 0x12, 0x13];
 
     let mut override_target_frame = None;


### PR DESCRIPTION
As in the commit messages, this PR includes these changes:

- Disable keys like "x" in replay takeover
- Load keybindings automatically in replay takeover
- Prevent replay from ending when took over 
- Make 4 keys used in takeover configurable

Feel free to tell me if you'd like to review and merge them separately, and I can separate them into multiple PRs if you need.