### PR TITLE
Hook Import table instead of instruction to apply heap_*_override

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,11 @@ use sound::RollbackSoundManager;
 use windows::{
     imp::{HeapAlloc, HeapFree, WaitForSingleObject},
     Win32::{
-        Foundation::{HMODULE, HWND},
+        Foundation::{HMODULE, HWND, TRUE},
         Networking::WinSock::closesocket,
         System::{
             Console::AllocConsole,
-            Memory::{VirtualProtect, PAGE_PROTECTION_FLAGS},
+            Memory::{VirtualProtect, PAGE_PROTECTION_FLAGS, PAGE_READWRITE},
         },
     },
 };


### PR DESCRIPTION
It might make debugging more easy, especially when dealing with call stacks with `heap_*_override` functions.