### PR TITLE
Disable `println!` by default and allow to configure it

### DIFF
--- a/giuroll.ini
+++ b/giuroll.ini
@@ -49,3 +49,6 @@ game_title="Touhou Hisoutensoku + $"
 
 ; Temporary solution to set default character mod as soku2, untill soku2 team can set it themselves
 soku2_compatibility_mode=yes
+
+; Enable println! which prints logs. `println!` sometimes crashes the game because of the error on printing.
+enable_println=no

--- a/src/netcode.rs
+++ b/src/netcode.rs
@@ -8,7 +8,7 @@ use std::{
 use windows::Win32::Networking::WinSock::{sendto, SOCKADDR, SOCKET};
 
 use crate::{
-    input_to_accum, read_key_better, rollback::Rollbacker, LIKELY_DESYNCED, SOKU_FRAMECOUNT,
+    input_to_accum, println, read_key_better, rollback::Rollbacker, LIKELY_DESYNCED, SOKU_FRAMECOUNT,
     TARGET_OFFSET,
 };
 

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -1,5 +1,5 @@
 use crate::{
-    pause, read_key_better, resume,
+    pause, read_key_better, println, resume,
     rollback::{dump_frame, Frame},
     MEMORY_RECEIVER_ALLOC, MEMORY_RECEIVER_FREE, SOKU_FRAMECOUNT,
 };

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -9,7 +9,7 @@ use std::{
 use windows::{imp::HeapFree, Win32::System::Memory::HeapHandle};
 
 use crate::{
-    set_input_buffer, ISDEBUG, MEMORY_RECEIVER_ALLOC, MEMORY_RECEIVER_FREE, SOKU_FRAMECOUNT,
+    println, set_input_buffer, ISDEBUG, MEMORY_RECEIVER_ALLOC, MEMORY_RECEIVER_FREE, SOKU_FRAMECOUNT,
     SOUND_MANAGER,
 };
 

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::{force_sound_skip, SOKU_FRAMECOUNT};
+use crate::{force_sound_skip, println, SOKU_FRAMECOUNT};
 
 pub struct RollbackSoundManager {
     sounds_that_did_happen: HashMap<usize, Vec<usize>>,


### PR DESCRIPTION
`println!` sometimes crashes the game because of the error on printing. To avoid this, `println!` is disabled unless feature `allocconsole` or debug is enabled. It can also enabled or disabled by `[Misc]`-> `enable_println` in giuroll.ini.