### PR TITLE
Add GitHub Action to build giuroll

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,21 @@ jobs:
           toolchain: nightly-2024-02-03
           targets: i686-pc-windows-msvc
       - run: cargo build --target i686-pc-windows-msvc --release --config profile.release.debug=true --config 'profile.release.split-debuginfo="packed"' --config 'profile.release.strip="none"'
-      - run: cp giuroll.ini target/i686-pc-windows-msvc/release/
+      - run: |
+          cp giuroll.ini target/i686-pc-windows-msvc/release/
+          cp LICENSE target/i686-pc-windows-msvc/release/LICENSE.txt
+          echo [InternetShortcut] > source-code-and-the-build.url
+          # https://stackoverflow.com/a/70566764
+          echo URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} >> source-code-and-the-build.url
+          cp source-code-and-the-build.url target/i686-pc-windows-msvc/release/
       - uses: actions/upload-artifact@v4
         with:
           name: Giuroll binary
           path: |
             target/i686-pc-windows-msvc/release/giuroll.dll
             target/i686-pc-windows-msvc/release/giuroll.ini
+            target/i686-pc-windows-msvc/release/LICENSE.txt
+            target/i686-pc-windows-msvc/release/source-code-and-the-build.url
       - uses: actions/upload-artifact@v4
         with:
           name: Giuroll symbols (PDB)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: build
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2024-02-03
+          targets: i686-pc-windows-msvc
+      - run: cargo build --target i686-pc-windows-msvc --release --config profile.release.debug=true --config 'profile.release.split-debuginfo="packed"' --config 'profile.release.strip="none"'
+      - run: cp giuroll.ini target/i686-pc-windows-msvc/release/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Giuroll binary
+          path: |
+            target/i686-pc-windows-msvc/release/giuroll.dll
+            target/i686-pc-windows-msvc/release/giuroll.ini
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Giuroll symbols (PDB)
+          path: |
+            target/i686-pc-windows-msvc/release/giuroll.pdb


### PR DESCRIPTION
To trigger it, manually run it on ["Action"](https://github.com/Giufin/giuroll/actions). If you want it to run automatically, change the `on: ` line (l2).